### PR TITLE
Anonymous login

### DIFF
--- a/lib/add_party/view/add_party.dart
+++ b/lib/add_party/view/add_party.dart
@@ -4,7 +4,6 @@ import 'package:taxi_hexa/add_party/components/components.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:taxi_hexa/add_party/view/widgets/widgets.dart';
 import 'package:taxi_hexa/app/components/components.dart';
-import 'package:taxi_hexa/app/components/modal.dart';
 
 class AddParty extends StatelessWidget {
   const AddParty({

--- a/lib/add_party/view/widgets/submit.dart
+++ b/lib/add_party/view/widgets/submit.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_database/firebase_database.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter/material.dart';
@@ -21,7 +22,7 @@ class Submit extends StatelessWidget {
     bool disabled = false;
     if (addPartyState.name.isEmpty) disabled = true;
     if (addPartyState.departure == null) disabled = true;
-    if (addPartyState.destination == null) disabled = true;
+    //if (addPartyState.destination == null) disabled = true;
     return FullWidthButton(
       "택시팟 만들기",
       onPressed: () async => _onPressed(context),
@@ -35,24 +36,28 @@ class Submit extends StatelessWidget {
     final locationState = context.read<LocationBloc>().state;
     final loginState = context.read<LoginBloc>().state;
     if (addPartyState.name == '') return;
-    if (addPartyState.destination?.description == null) return;
+    //if (addPartyState.destination?.description == null) return;
     if (addPartyState.departure == null) return;
 
     String id = const Uuid().v1();
     DatabaseReference ref = FirebaseDatabase.instance.ref(
       "parties/taxi_party${id.toString()}",
     );
-    LatLng destination = await getDestinationCoordinate(
+    /*LatLng destination = await getDestinationCoordinate(
       context,
       addPartyState.destination!.placeId!,
-    );
+    );*/
     TaxiPartyModel newParty = TaxiPartyModel(
       id: id,
       name: addPartyState.name,
-      destination: destination,
-      destinationAddress: addPartyState.destination!.description!, // 주소
-      currentPosition: locationState.currentLocation,
-      members: <String?>[loginState.userInfo?.id],
+      destination: new LatLng(0, 0), //destination,
+      destinationAddress:
+          "Somewhere Over the Rainbow", //addPartyState.destination!.description!, // 주소
+      currentPosition:
+          new LatLng(35.907757, 127.766922), //locationState.currentLocation,
+      members: (loginState.isLoggedIn)
+          ? <String?>[loginState.userInfo?.id]
+          : <String?>[currentuser!.user!.uid.toString()],
       departure: addPartyState.departure!,
       description: addPartyState.description,
     );

--- a/lib/add_party/view/widgets/submit.dart
+++ b/lib/add_party/view/widgets/submit.dart
@@ -50,7 +50,7 @@ class Submit extends StatelessWidget {
     TaxiPartyModel newParty = TaxiPartyModel(
       id: id,
       name: addPartyState.name,
-      destination: new LatLng(0, 0), //destination,
+      destination: new LatLng(35.90776, 127.7669), //destination,
       destinationAddress:
           "Somewhere Over the Rainbow", //addPartyState.destination!.description!, // 주소
       currentPosition:

--- a/lib/home/models/taxi_party.dart
+++ b/lib/home/models/taxi_party.dart
@@ -25,10 +25,10 @@ class TaxiPartyModel {
   TaxiPartyModel({
     required this.id,
     required this.name,
-    required this.destination,
+    this.destination,
     required this.destinationAddress,
     required this.currentPosition,
-    required this.members,
+    required this.members, //가장 첫 유저가 관리자.
     required this.departure,
     this.description,
   });

--- a/lib/home/view/widgets/party_info.dart
+++ b/lib/home/view/widgets/party_info.dart
@@ -10,6 +10,7 @@ import 'package:firebase_database/firebase_database.dart';
 
 class PartyInfo extends StatelessWidget {
   PartyInfo({Key? key}) : super(key: key);
+  bool joinActive = true;
   @override
   Widget build(BuildContext context) {
     final state = context.watch<LocationBloc>().state;
@@ -32,30 +33,34 @@ class PartyInfo extends StatelessWidget {
             (currentuser!.user!.uid.toString() == party.members.first)
                 ? ElevatedButton(onPressed: () {}, child: Text("수정"))
                 : (party.members
-                            .where((element) =>
-                                element == currentuser!.user!.uid.toString())
-                            .length ==
-                        0)
+                        .where((element) =>
+                            element == currentuser!.user!.uid.toString())
+                        .isEmpty)
                     ? ElevatedButton(
-                        onPressed: () {
-                          party.members.add(currentuser!.user!.uid.toString());
-                          FirebaseDatabase.instance.ref().update({
-                            "parties/taxi_party${party.id}/members":
+                        onPressed: (joinActive)
+                            ? () {
                                 party.members
-                          });
-                        },
+                                    .add(currentuser!.user!.uid.toString());
+                                FirebaseDatabase.instance.ref().update({
+                                  "parties/taxi_party${party.id}/members":
+                                      party.members
+                                });
+                                joinActive = false;
+                              }
+                            : null,
                         child: Text("참여"))
                     : ElevatedButton(
-                        onPressed: () {
-                          print(party.members.where((element) =>
-                              element == currentuser!.user!.uid.toString()));
-                          party.members
-                              .remove(currentuser!.user!.uid.toString());
-                          FirebaseDatabase.instance.ref().update({
-                            "parties/taxi_party${party.id}/members":
+                        onPressed: (joinActive)
+                            ? () {
                                 party.members
-                          });
-                        },
+                                    .remove(currentuser!.user!.uid.toString());
+                                FirebaseDatabase.instance.ref().update({
+                                  "parties/taxi_party${party.id}/members":
+                                      party.members
+                                });
+                                joinActive = false;
+                              }
+                            : null,
                         child: Text("탈퇴")),
           ],
         ),

--- a/lib/home/view/widgets/party_info.dart
+++ b/lib/home/view/widgets/party_info.dart
@@ -4,6 +4,7 @@ import 'package:taxi_hexa/home/models/taxi_party.dart';
 import 'package:taxi_hexa/location/location.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:collection/collection.dart';
+import 'package:taxi_hexa/login/bloc/login_bloc.dart';
 import 'package:taxi_hexa/themes/text_styles.dart';
 
 class PartyInfo extends StatelessWidget {
@@ -19,10 +20,19 @@ class PartyInfo extends StatelessWidget {
       children: [
         const DragBar(),
         const SizedBox(height: 10),
-        Text(
-          party!.name,
-          textAlign: TextAlign.start,
-          style: AppTextStyles.heading,
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Text(
+              party!.name,
+              textAlign: TextAlign.start,
+              style: AppTextStyles.heading,
+            ),
+            (currentuser!.user!.uid.toString() == party.members.first)
+                ? ElevatedButton(onPressed: () {}, child: Text("수정"))
+                : const Text("no"),
+          ],
         ),
         const SizedBox(height: 10),
         _SubHeading(party: party),

--- a/lib/home/view/widgets/party_info.dart
+++ b/lib/home/view/widgets/party_info.dart
@@ -6,10 +6,10 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:collection/collection.dart';
 import 'package:taxi_hexa/login/bloc/login_bloc.dart';
 import 'package:taxi_hexa/themes/text_styles.dart';
+import 'package:firebase_database/firebase_database.dart';
 
 class PartyInfo extends StatelessWidget {
-  const PartyInfo({Key? key}) : super(key: key);
-
+  PartyInfo({Key? key}) : super(key: key);
   @override
   Widget build(BuildContext context) {
     final state = context.watch<LocationBloc>().state;
@@ -31,9 +31,36 @@ class PartyInfo extends StatelessWidget {
             ),
             (currentuser!.user!.uid.toString() == party.members.first)
                 ? ElevatedButton(onPressed: () {}, child: Text("수정"))
-                : const Text("no"),
+                : (party.members
+                            .where((element) =>
+                                element == currentuser!.user!.uid.toString())
+                            .length ==
+                        0)
+                    ? ElevatedButton(
+                        onPressed: () {
+                          party.members.add(currentuser!.user!.uid.toString());
+                          FirebaseDatabase.instance.ref().update({
+                            "parties/taxi_party${party.id}/members":
+                                party.members
+                          });
+                        },
+                        child: Text("참여"))
+                    : ElevatedButton(
+                        onPressed: () {
+                          print(party.members.where((element) =>
+                              element == currentuser!.user!.uid.toString()));
+                          party.members
+                              .remove(currentuser!.user!.uid.toString());
+                          FirebaseDatabase.instance.ref().update({
+                            "parties/taxi_party${party.id}/members":
+                                party.members
+                          });
+                        },
+                        child: Text("탈퇴")),
           ],
         ),
+        const SizedBox(height: 10),
+        Text("인원 수: ${party.members.length.toString()}명"),
         const SizedBox(height: 10),
         _SubHeading(party: party),
         const SizedBox(height: 10),

--- a/lib/home/view/widgets/taxi_map.dart
+++ b/lib/home/view/widgets/taxi_map.dart
@@ -154,7 +154,7 @@ class _TaxiMapState extends State<TaxiMap> with WidgetsBindingObserver {
           );
           showModalBottomSheet(
             context: context,
-            builder: (_) => const PartyInfo(),
+            builder: (_) => PartyInfo(),
           );
         });
     return marker;

--- a/lib/login/bloc/login_bloc.dart
+++ b/lib/login/bloc/login_bloc.dart
@@ -1,9 +1,12 @@
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:taxi_hexa/login/models/user.dart';
 
 part 'login_event.dart';
 part 'login_state.dart';
+
+UserCredential? currentuser;
 
 class LoginBloc extends Bloc<LoginEvent, LoginState> {
   LoginBloc() : super(const LoginState.initial()) {

--- a/lib/login/view/login.dart
+++ b/lib/login/view/login.dart
@@ -40,18 +40,18 @@ class Login extends AbstractForm {
 
   void login(BuildContext context) async {
     try {
-      final newUser = await auth.signInWithEmailAndPassword(
+      currentuser = await auth.signInWithEmailAndPassword(
         email: email,
         password: password,
       );
-      if (newUser.user == null) throw Exception("User not found");
+      if (currentuser!.user == null) throw Exception("User not found");
       final bloc = context.read<LoginBloc>();
       bloc.add(
         LoggedIn(
           UserModel(
-            id: newUser.user!.uid,
-            name: newUser.additionalUserInfo?.username ??
-                newUser.user!.displayName ??
+            id: currentuser!.user!.uid,
+            name: currentuser!.additionalUserInfo?.username ??
+                currentuser!.user!.displayName ??
                 email,
           ),
         ),

--- a/lib/login/view/signin.dart
+++ b/lib/login/view/signin.dart
@@ -36,11 +36,11 @@ class SignUp extends AbstractForm {
 
   void signup(BuildContext context) async {
     try {
-      final newUser = await auth.createUserWithEmailAndPassword(
-        email: email,
-        password: password,
-      );
-      if (newUser.user == null) throw Exception("User not created");
+      final credential =
+          EmailAuthProvider.credential(email: email, password: password);
+      final newUser = await FirebaseAuth.instance.currentUser
+          ?.linkWithCredential(credential);
+      if (newUser!.user == null) throw Exception("User not created");
       final bloc = context.read<LoginBloc>();
       bloc.add(
         LoggedIn(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,10 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:taxi_hexa/app/app.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:taxi_hexa/login/login.dart';
 
 void main() async {
   await dotenv.load();
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp();
+  currentuser = await FirebaseAuth.instance.signInAnonymously();
   runApp(const App());
 }


### PR DESCRIPTION
테스트를 위해서 submit.dart에서 destination 값을 받도록 검사하는 부분들이랑 관련 데이터를 데이터베이스를 옮기는 부분을 주석처리 했어요.


익명 로그인을 구현했어요.
- login_bloc.dart에 전역변수로 UserCredential?값인  currentuser을 만들었어요. 앱을 시작함과 동시에 익명로그인을 하면 그 계정 정보가 여기에 담기고, 로그인을 하거나 회원가입을 하면 그 계정 정보로  바껴요.
-  signin.dart에 signup 함수 내용을 '새로 계정을 만드는 거'에서 '익명로그인한 계정정보를 이어가도록' 수정했어요.


party_info.dart를 많이 손봤어요.
- 일단 오른쪽 위에 버튼이 하나 뜨도록 했어요. 파티를 생성한 사람이라면 '수정', 아니라면 '참여'or탈퇴'
- party의 members에 user의 id가 없다면 '참여', 있다면 '탈퇴'가 떠요.
- **참여와 탈퇴버튼을 무한히 누를 수 있는 문제가 있어요.** (수정해보려고 joinActive라는 bool값을 만들어봤는데 실패했네요.)
- 파티의 인원 수를 세서 표시하도록 했어요. **바로바로 변화가 반영이 안되는 문제가 있어요.**